### PR TITLE
Changing to generic email service

### DIFF
--- a/build-program2.html
+++ b/build-program2.html
@@ -3364,7 +3364,7 @@
             email = document.getElementsByName('email')[0]?.value || '';
             companyName = document.getElementsByName('companyName')[0]?.value || '';
 
-            emailjs.send("service_00hboeb", "template_1cfzg9f", {
+            emailjs.send("service_ag1505e", "template_1cfzg9f", {
               planList: formattedPlans,
               affiliateName: affiliateName,
               affiliateEmail: affiliateEmail,


### PR DESCRIPTION
I think this is correct to send from Recognition-programs@webdevmail.com instead of the promomonster@webdevmail.com one.